### PR TITLE
fix some documentation stuff

### DIFF
--- a/gd/client.py
+++ b/gd/client.py
@@ -1293,7 +1293,7 @@ class Client:
 
         Parameters
         ----------
-        query: :class:`int`
+        query: :class:`str`
             A query to search with.
 
         filters: :class:`.Filters`


### PR DESCRIPTION
in search_levels, change query documentation to str instead of the incorrect int

### Summary

<!-- What is this pull request for? Does it fix any issues? -->
small documentation change, change query from the incorrect `int` to the correct `str` in search_levels
### Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new class, method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation update, README, etc.)
