### PR TITLE
#88: Fix uncaught UnicodeDecodeError in search_levels

### DIFF
--- a/gd/encoding.py
+++ b/gd/encoding.py
@@ -74,7 +74,6 @@ __all__ = (
     "generate_leaderboard_seed",
     "compress",
     "decompress",
-    "fix_song_encoding",
 )
 
 # zlib headers
@@ -421,11 +420,3 @@ def decompress(data: bytes) -> bytes:
 
 LEGACY = "cp1252"
 UTF_8 = "utf-8"
-
-
-def fix_song_encoding(string: str, errors: str = DEFAULT_ERRORS) -> str:
-    try:
-        return string.encode(LEGACY, errors).decode(UTF_8, errors)
-
-    except (UnicodeEncodeError, UnicodeDecodeError):
-        return string

--- a/gd/http.py
+++ b/gd/http.py
@@ -75,6 +75,7 @@ from gd.encoding import (
     ATTEMPTS_ADD,
     CLICKS_ADD,
     COINS_ADD,
+    LEGACY,
     SECONDS_ADD,
     UTF_8,
     encode_base64_string_url_safe,
@@ -802,6 +803,7 @@ class HTTPClient:
         error: Optional[AnyError] = None
 
         utf_8 = UTF_8
+        legacy = LEGACY
 
         while attempts:
             try:
@@ -822,7 +824,10 @@ class HTTPClient:
                         response_data = await response.read()
 
                     elif type is ResponseType.TEXT:
-                        response_data = await response.text(encoding=utf_8)
+                        try:
+                            response_data = await response.text(encoding=utf_8)
+                        except UnicodeDecodeError:
+                            response_data = await response.text(encoding=legacy)
 
                     elif type is ResponseType.JSON:
                         response_data = await response.json(content_type=None)


### PR DESCRIPTION
Added legacy encoding to http::request as a backup, removed fix_song_encoding method as unnecessary.