### PR TITLE
#92: add Practice: Stay Inside Me to the list of official songs

### DIFF
--- a/gd/official_songs.py
+++ b/gd/official_songs.py
@@ -21,6 +21,7 @@ class OfficialSong:
 
 
 OFFICIAL_SONGS = (
+    OfficialSong(id=-1, name="Practice: Stay Inside Me", artist_name="OcularNebula"),
     OfficialSong(id=0, name="Stereo Madness", artist_name="ForeverBound"),
     OfficialSong(id=1, name="Back On Track", artist_name="DJVI"),
     OfficialSong(id=2, name="Polargeist", artist_name="Step"),

--- a/gd/song.py
+++ b/gd/song.py
@@ -239,7 +239,7 @@ class Song(Entity):
                 official_song = OfficialSong.default(id=id)
 
         return cls(
-            id=official_song.id,
+            id=official_song.id if official_song.id != -1 else 0,  # get rid of the negative id of the practice song
             custom=False,
             name=official_song.name,
             artist=Artist.name_only(official_song.artist_name),


### PR DESCRIPTION
Id of the practice song is changed to 0 before the creation of the Song object, making the validation pass. The same solution is used in GD since you hear Stereo Madness (id 0) when playing a level with this song.